### PR TITLE
badgeName의 type을 BadgeName으로 변경

### DIFF
--- a/src/main/java/com/divide/badge/Badge.java
+++ b/src/main/java/com/divide/badge/Badge.java
@@ -14,7 +14,7 @@ public class Badge {
 
     @NotNull
     @Enumerated(EnumType.STRING)
-    private String BadgeName;
+    private BadgeName badgeName;
 
     @NotNull
     private String iconUrl;


### PR DESCRIPTION
## 제목
badgeName의 type을 BadgeName으로 변경

## 작업 내용
- badgeName의 type이 String이어서 컴파일 되지 않던 문제를 hotfix

## 주의 사항
- 

## 이슈 번호
- 