### PR TITLE
카카오 로그인 오류 해결

### DIFF
--- a/src/main/java/com/divide/auth/AuthController.java
+++ b/src/main/java/com/divide/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.divide.auth;
 
 import com.divide.BaseResponseStatus;
+import com.divide.auth.dto.request.KakaoLoginRequest;
 import com.divide.auth.dto.response.KakaoLoginResponse;
 import com.divide.security.JwtFilter;
 import com.divide.BaseResponse;
@@ -44,11 +45,10 @@ public class AuthController {
 
     @PostMapping("/auth/kakao")
     public ResponseEntity<BaseResponse> kakaoLogin(
-        @Nullable @RequestBody String code
+        @Valid @RequestBody KakaoLoginRequest kakaoLoginRequest
     ) throws JsonProcessingException {
-        if (code == null) return new ResponseEntity(new BaseResponse(BaseResponseStatus.DATABASE_ERROR), HttpStatus.BAD_REQUEST);
 
-        KakaoLoginResponse kakaoLoginResponse = authService.kakaoLogin(code, "http://localhost:8080/api/v1/auth/kakaoTest");
+        KakaoLoginResponse kakaoLoginResponse = authService.kakaoLogin(kakaoLoginRequest.getCode(), "http://localhost:8080/api/v1/auth/kakaoTest");
         String jwt = tokenProvider.createToken(kakaoLoginResponse.getEmail(), kakaoLoginResponse.getPassword());
 
         HttpHeaders httpHeaders = new HttpHeaders();

--- a/src/main/java/com/divide/auth/AuthController.java
+++ b/src/main/java/com/divide/auth/AuthController.java
@@ -5,6 +5,7 @@ import com.divide.auth.dto.response.KakaoLoginResponse;
 import com.divide.security.JwtFilter;
 import com.divide.BaseResponse;
 import com.divide.auth.dto.request.LoginRequest;
+import com.divide.security.TokenProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
@@ -19,12 +20,13 @@ import javax.websocket.server.PathParam;
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+    private final TokenProvider tokenProvider;
 
     @PostMapping("/auth/login")
     public ResponseEntity<BaseResponse> login(
             @Valid @RequestBody LoginRequest loginRequest
     ) {
-        String jwt = authService.genJwt(loginRequest.getEmail(), loginRequest.getPassword());
+        String jwt = tokenProvider.createToken(loginRequest.getEmail(), loginRequest.getPassword());
 
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + jwt);
@@ -39,7 +41,7 @@ public class AuthController {
         if (code == null) return new ResponseEntity(new BaseResponse(BaseResponseStatus.DATABASE_ERROR), HttpStatus.BAD_REQUEST);
 
         KakaoLoginResponse kakaoLoginResponse = authService.kakaoLogin(code, "http://localhost:8080/api/v1/auth/kakao");
-        String jwt = authService.genJwt(kakaoLoginResponse.getEmail(), kakaoLoginResponse.getPassword());
+        String jwt = tokenProvider.createToken(kakaoLoginResponse.getEmail(), kakaoLoginResponse.getPassword());
 
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + jwt);

--- a/src/main/java/com/divide/auth/AuthController.java
+++ b/src/main/java/com/divide/auth/AuthController.java
@@ -13,6 +13,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.websocket.server.PathParam;
 
 @RestController
@@ -34,13 +35,20 @@ public class AuthController {
         return new ResponseEntity(new BaseResponse(jwt), httpHeaders, HttpStatus.OK);
     }
 
-    @GetMapping("/auth/kakao")
+    @GetMapping("/auth/kakaoTest")
+    public void kakaoTest(
+            @NotNull @RequestParam("code") String code
+    ) {
+        System.out.println("code = " + code);
+    }
+
+    @PostMapping("/auth/kakao")
     public ResponseEntity<BaseResponse> kakaoLogin(
-        @Nullable @PathParam("code") String code
+        @Nullable @RequestBody String code
     ) throws JsonProcessingException {
         if (code == null) return new ResponseEntity(new BaseResponse(BaseResponseStatus.DATABASE_ERROR), HttpStatus.BAD_REQUEST);
 
-        KakaoLoginResponse kakaoLoginResponse = authService.kakaoLogin(code, "http://localhost:8080/api/v1/auth/kakao");
+        KakaoLoginResponse kakaoLoginResponse = authService.kakaoLogin(code, "http://localhost:8080/api/v1/auth/kakaoTest");
         String jwt = tokenProvider.createToken(kakaoLoginResponse.getEmail(), kakaoLoginResponse.getPassword());
 
         HttpHeaders httpHeaders = new HttpHeaders();

--- a/src/main/java/com/divide/auth/AuthService.java
+++ b/src/main/java/com/divide/auth/AuthService.java
@@ -1,7 +1,5 @@
 package com.divide.auth;
 
-import com.divide.BaseException;
-import com.divide.BaseResponseStatus;
 import com.divide.auth.dto.response.KakaoLoginResponse;
 import com.divide.security.TokenProvider;
 import com.divide.user.User;
@@ -14,9 +12,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,8 +26,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Transactional
 public class AuthService {
-    private final TokenProvider tokenProvider;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
@@ -98,17 +92,5 @@ public class AuthService {
         ObjectMapper objectMapper = new ObjectMapper();
         Map json = objectMapper.readValue(response.getBody(), Map.class);
         return (Map) json.get("kakao_account");
-    }
-
-    @Transactional(readOnly = true)
-    public String genJwt(final String email, final String password) {
-        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                new UsernamePasswordAuthenticationToken(email, password);
-
-        Authentication authentication = authenticationManagerBuilder
-                .getObject()
-                .authenticate(usernamePasswordAuthenticationToken);
-
-        return tokenProvider.createToken(authentication);
     }
 }

--- a/src/main/java/com/divide/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/divide/auth/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,11 @@
+package com.divide.auth.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class KakaoLoginRequest {
+    @NotNull
+    private String code;
+}

--- a/src/main/java/com/divide/badge/Badge.java
+++ b/src/main/java/com/divide/badge/Badge.java
@@ -14,7 +14,7 @@ public class Badge {
 
     @NotNull
     @Enumerated(EnumType.STRING)
-    private String BadgeName;
+    private BadgeName badgeName;
 
     @NotNull
     private String iconUrl;


### PR DESCRIPTION
## 제목
카카오 로그인 오류 해결

## 작업 내용
- TokenProvider 구조 단순화
- jwt 생성 로직을 TokenProvider로 모두 위임
- 카카오 로그인 시 항상 오류가 나던 문제 해결
- 카카오 로그인 테스트용 api 생성
- 카카오 로그인 Request의 type이 String으로, 제대로 매핑되지 않아 Request추가

## 주의 사항
- 

## 이슈 번호
- #15 