### PR TITLE
Post /api/v1/follow 구현

### DIFF
--- a/src/main/java/com/divide/follow/Follow.java
+++ b/src/main/java/com/divide/follow/Follow.java
@@ -10,6 +10,9 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Entity
 @NoArgsConstructor
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"follower_id", "followee_id"})
+})
 public class Follow {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "follow_id")

--- a/src/main/java/com/divide/follow/FollowController.java
+++ b/src/main/java/com/divide/follow/FollowController.java
@@ -1,14 +1,13 @@
 package com.divide.follow;
 
 import com.divide.follow.dto.request.GetFollowResponse;
+import com.divide.follow.dto.request.PostFollowRequest;
+import com.divide.follow.dto.response.PostFollowResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +27,14 @@ public class FollowController {
             case FOLLOWER -> getFollowResponse = followService.getFollowerList(userDetails.getUsername());
         }
         return ResponseEntity.ok(getFollowResponse);
+    }
+
+    @PostMapping("follow")
+    public ResponseEntity<PostFollowResponse> postFollow(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody PostFollowRequest postFollowRequest
+    ) {
+        Long saveId = followService.save(userDetails.getUsername(), postFollowRequest.getUserId());
+        return ResponseEntity.status(201).body(new PostFollowResponse(saveId));
     }
 }

--- a/src/main/java/com/divide/follow/FollowService.java
+++ b/src/main/java/com/divide/follow/FollowService.java
@@ -4,6 +4,7 @@ import com.divide.follow.dto.request.GetFollowResponse;
 import com.divide.user.User;
 import com.divide.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,10 +18,12 @@ public class FollowService {
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
 
-    public void save(String myUserEmail, Long targetId) {
-        User myUser = userRepository.findByEmail(myUserEmail).orElseThrow();
+    public Long save(String myUserEmail, Long targetId) {
+        User myUser = userRepository.findByEmail(myUserEmail).orElseThrow(() -> new UsernameNotFoundException(""));
         User targetUser = userRepository.findById(targetId);
-        followRepository.save(new Follow(myUser, targetUser));
+        Follow newFollow = new Follow(myUser, targetUser);
+        followRepository.save(newFollow);
+        return newFollow.getId();
     }
 
     public GetFollowResponse getFFFList(String userEmail) {

--- a/src/main/java/com/divide/follow/dto/request/PostFollowRequest.java
+++ b/src/main/java/com/divide/follow/dto/request/PostFollowRequest.java
@@ -1,0 +1,10 @@
+package com.divide.follow.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostFollowRequest {
+    private Long userId;
+}

--- a/src/main/java/com/divide/follow/dto/response/PostFollowResponse.java
+++ b/src/main/java/com/divide/follow/dto/response/PostFollowResponse.java
@@ -1,0 +1,10 @@
+package com.divide.follow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostFollowResponse {
+    private Long followId;
+}

--- a/src/main/java/com/divide/post/InitDb.java
+++ b/src/main/java/com/divide/post/InitDb.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,9 +35,10 @@ public class InitDb {
     @RequiredArgsConstructor
     static class InitService {
         private final EntityManager em;
+        private final PasswordEncoder passwordEncoder;
         public void dbInit1() throws ParseException {
             //String email, String password, String profileImgUrl, String nickname, UserRole role
-            User user1 = new User("email@gmail.com", "password1", "profileImgUrl1", "nickname1", USER );
+            User user1 = new User("email@gmail.com", passwordEncoder.encode("password1"), "profileImgUrl1", "nickname1", USER );
             em.persist(user1);
 
             //deliveryLocation
@@ -57,7 +60,7 @@ public class InitDb {
                     .postStatus(PostStatus.RECRUIT_FAIL)
                     .build();
 
-            Point point2 = (Point) new WKTReader().read("POINT(127.030 37.490154)");
+            Point point2 = (Point) new WKTReader().read("POINT(37.4895303786052 127.030436319555)");
 
             Post post2 = Post.builder()
                     .user(user1)
@@ -72,8 +75,200 @@ public class InitDb {
                     .postStatus(PostStatus.RECRUITING)
                     .build();
 
+            Point point3 = (Point) new WKTReader().read("POINT(37.4895773750866 127.03067318021)");
+
+            Post post3 = Post.builder()
+                    .user(user1)
+                    .title("title3")
+                    .storeName("storeName3")
+                    .content("content3")
+                    .targetPrice(30000)
+                    .deliveryPrice(2000)
+                    .category(Category.JAPANESE_FOOD)
+                    .targetTime(LocalDateTime.now().plusHours(1))
+                    .deliveryLocation(point3)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point4 = (Point) new WKTReader().read("POINT(37.4895303786052 127.030436319555)");
+
+            Post post4 = Post.builder()
+                    .user(user1)
+                    .title("title4")
+                    .storeName("storeName4")
+                    .content("content4")
+                    .targetPrice(60000)
+                    .deliveryPrice(3000)
+                    .category(Category.KOREAN_FOOD)
+                    .targetTime(LocalDateTime.now().plusHours(1))
+                    .deliveryLocation(point4)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point5 = (Point) new WKTReader().read("POINT(37.4895773750866 127.030673180212)");
+
+            Post post5 = Post.builder()
+                    .user(user1)
+                    .title("title5")
+                    .storeName("storeName5")
+                    .content("content5")
+                    .targetPrice(50000)
+                    .deliveryPrice(5000)
+                    .category(Category.DESSERT)
+                    .targetTime(LocalDateTime.now().plusHours(3))
+                    .deliveryLocation(point5)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point6 = (Point) new WKTReader().read("POINT(37.4895773750866 127.030673180212)");
+
+            Post post6 = Post.builder()
+                    .user(user1)
+                    .title("title6")
+                    .storeName("storeName6")
+                    .content("content6")
+                    .targetPrice(60000)
+                    .deliveryPrice(42000)
+                    .category(Category.KOREAN_FOOD)
+                    .targetTime(LocalDateTime.now().plusHours(6))
+                    .deliveryLocation(point6)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point7 = (Point) new WKTReader().read("POINT(37.4895773750866 127.03067318021)");
+
+            Post post7 = Post.builder()
+                    .user(user1)
+                    .title("title7")
+                    .storeName("storeName7")
+                    .content("content7")
+                    .targetPrice(70000)
+                    .deliveryPrice(2000)
+                    .category(Category.JAPANESE_FOOD)
+                    .targetTime(LocalDateTime.now().plusHours(1))
+                    .deliveryLocation(point7)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point8 = (Point) new WKTReader().read("POINT(37.4901548250937 127.030767490957)");
+
+            Post post8 = Post.builder()
+                    .user(user1)
+                    .title("title8")
+                    .storeName("storeName8")
+                    .content("content8")
+                    .targetPrice(30000)
+                    .deliveryPrice(4000)
+                    .category(Category.KOREAN_FOOD)
+                    .targetTime(LocalDateTime.now().plusHours(1))
+                    .deliveryLocation(point8)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point9 = (Point) new WKTReader().read("POINT(37.4901548250937 127.030767490957)");
+
+            Post post9 = Post.builder()
+                    .user(user1)
+                    .title("title9")
+                    .storeName("storeName9")
+                    .content("content9")
+                    .targetPrice(55000)
+                    .deliveryPrice(25000)
+                    .category(Category.DESSERT)
+                    .targetTime(LocalDateTime.now().plusHours(3))
+                    .deliveryLocation(point9)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point10 = (Point) new WKTReader().read("POINT(37.4901548250937 127.030767490957)");
+
+            Post post10 = Post.builder()
+                    .user(user1)
+                    .title("title10")
+                    .storeName("storeName10")
+                    .content("content10")
+                    .targetPrice(55000)
+                    .deliveryPrice(25000)
+                    .category(Category.DESSERT)
+                    .targetTime(LocalDateTime.now().plusHours(3))
+                    .deliveryLocation(point10)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point11 = (Point) new WKTReader().read("POINT(85.4901548250937 17.03076749095)");
+
+            Post post11 = Post.builder()
+                    .user(user1)
+                    .title("title11")
+                    .storeName("storeName11")
+                    .content("content11")
+                    .targetPrice(50000)
+                    .deliveryPrice(5000)
+                    .category(Category.DESSERT)
+                    .targetTime(LocalDateTime.now().plusHours(3))
+                    .deliveryLocation(point11)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point12 = (Point) new WKTReader().read("POINT(97.4895303786052 27.030436355)");
+
+            Post post12 = Post.builder()
+                    .user(user1)
+                    .title("title12")
+                    .storeName("storeName12")
+                    .content("content12")
+                    .targetPrice(60000)
+                    .deliveryPrice(42000)
+                    .category(Category.KOREAN_FOOD)
+                    .targetTime(LocalDateTime.now().plusHours(2))
+                    .deliveryLocation(point12)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point13 = (Point) new WKTReader().read("POINT(14.4812233750866 12.03067318021)");
+
+            Post post13 = Post.builder()
+                    .user(user1)
+                    .title("title13")
+                    .storeName("storeName13")
+                    .content("content13")
+                    .targetPrice(70000)
+                    .deliveryPrice(2000)
+                    .category(Category.JAPANESE_FOOD)
+                    .targetTime(LocalDateTime.now().plusHours(1))
+                    .deliveryLocation(point13)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
+            Point point14 = (Point) new WKTReader().read("POINT(7.4895773340866 72.030673180212)");
+
+            Post post14 = Post.builder()
+                    .user(user1)
+                    .title("title14")
+                    .storeName("storeName14")
+                    .content("content14")
+                    .targetPrice(30000)
+                    .deliveryPrice(4000)
+                    .category(Category.KOREAN_FOOD)
+                    .targetTime(LocalDateTime.now().plusHours(1))
+                    .deliveryLocation(point14)
+                    .postStatus(PostStatus.RECRUITING)
+                    .build();
+
             em.persist(post1);
             em.persist(post2);
+            em.persist(post3);
+            em.persist(post4);
+            em.persist(post5);
+            em.persist(post6);
+            em.persist(post7);
+            em.persist(post8);
+            em.persist(post9);
+            em.persist(post10);
+            em.persist(post11);
+            em.persist(post12);
+            em.persist(post13);
+            em.persist(post14);
 
         }
     }

--- a/src/test/java/com/divide/follow/FollowServiceTest.java
+++ b/src/test/java/com/divide/follow/FollowServiceTest.java
@@ -1,17 +1,22 @@
 package com.divide.follow;
 
+import com.divide.follow.dto.request.GetFollowResponse;
 import com.divide.user.User;
 import com.divide.user.UserService;
 import com.divide.user.dto.request.SignupRequest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
+@Transactional
 class FollowServiceTest {
     @Autowired
     private FollowService followService;
@@ -19,77 +24,123 @@ class FollowServiceTest {
     @Autowired
     private UserService userService;
 
-    @Test
+    @BeforeEach
     @Transactional
+    void setUp() {
+        userService.signup(new SignupRequest("email1@gmail.com", "password1", "url1", "nick1"));
+        userService.signup(new SignupRequest("email2@gmail.com", "password2", "url2", "nick2"));
+        userService.signup(new SignupRequest("email3@gmail.com", "password3", "url3", "nick3"));
+        userService.signup(new SignupRequest("email4@gmail.com", "password4", "url4", "nick4"));
+        userService.signup(new SignupRequest("email5@gmail.com", "password5", "url5", "nick5"));
+        userService.signup(new SignupRequest("email6@gmail.com", "password6", "url6", "nick6"));
+        userService.signup(new SignupRequest("email7@gmail.com", "password7", "url7", "nick7"));
+        userService.signup(new SignupRequest("email8@gmail.com", "password8", "url8", "nick8"));
+        userService.signup(new SignupRequest("email9@gmail.com", "password9", "url9", "nick9"));
+    }
+
+    @Test
     public void followingTest() throws Exception {
         // given
-        userService.signup(new SignupRequest("email1@gmail.com", "password1", "url1", "nick1"));
         User user1 = userService.getUserByEmail("email1@gmail.com");
-
-        userService.signup(new SignupRequest("email2@gmail.com", "password2", "url2", "nick2"));
         User user2 = userService.getUserByEmail("email2@gmail.com");
-
-        userService.signup(new SignupRequest("email3@gmail.com", "password3", "url3", "nick3"));
         User user3 = userService.getUserByEmail("email3@gmail.com");
+        User user4 = userService.getUserByEmail("email4@gmail.com");
+        User user5 = userService.getUserByEmail("email5@gmail.com");
+        User user6 = userService.getUserByEmail("email6@gmail.com");
+        User user7 = userService.getUserByEmail("email7@gmail.com");
+        User user8 = userService.getUserByEmail("email8@gmail.com");
+        User user9 = userService.getUserByEmail("email9@gmail.com");
 
         // when
         followService.save(user1.getEmail(), user2.getId());
         followService.save(user1.getEmail(), user3.getId());
+        followService.save(user3.getEmail(), user4.getId());
+        followService.save(user3.getEmail(), user5.getId());
+        followService.save(user3.getEmail(), user6.getId());
+        followService.save(user3.getEmail(), user7.getId());
+        followService.save(user3.getEmail(), user8.getId());
+        followService.save(user3.getEmail(), user9.getId());
 
         // then
-        assertEquals(2, followService.getFollowingList(user1.getEmail()).getFollowList().size());
-        assertEquals(0, followService.getFollowingList(user2.getEmail()).getFollowList().size());
-        assertEquals(0, followService.getFollowingList(user3.getEmail()).getFollowList().size());
+        assertEquals(List.of(user2.getId(), user3.getId()),
+                followService.getFollowingList(user1.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+        assertEquals(List.of(),
+                followService.getFollowingList(user2.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+        assertEquals(List.of(user4.getId(), user5.getId(), user6.getId(), user7.getId(), user8.getId(), user9.getId()),
+                followService.getFollowingList(user3.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+        assertEquals(List.of(),
+                followService.getFollowingList(user8.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
     }
 
     @Test
-    @Transactional
     public void followerTest() throws Exception {
         // given
-        userService.signup(new SignupRequest("email1@gmail.com", "password1", "url1", "nick1"));
         User user1 = userService.getUserByEmail("email1@gmail.com");
-
-        userService.signup(new SignupRequest("email2@gmail.com", "password2", "url2", "nick2"));
         User user2 = userService.getUserByEmail("email2@gmail.com");
-
-        userService.signup(new SignupRequest("email3@gmail.com", "password3", "url3", "nick3"));
         User user3 = userService.getUserByEmail("email3@gmail.com");
+        User user4 = userService.getUserByEmail("email4@gmail.com");
+        User user5 = userService.getUserByEmail("email5@gmail.com");
+        User user6 = userService.getUserByEmail("email6@gmail.com");
+        User user7 = userService.getUserByEmail("email7@gmail.com");
+        User user8 = userService.getUserByEmail("email8@gmail.com");
+        User user9 = userService.getUserByEmail("email9@gmail.com");
 
         // when
         followService.save(user1.getEmail(), user2.getId());
         followService.save(user1.getEmail(), user3.getId());
-        followService.save(user2.getEmail(), user3.getId());
+        followService.save(user3.getEmail(), user4.getId());
+        followService.save(user3.getEmail(), user5.getId());
+        followService.save(user3.getEmail(), user6.getId());
+        followService.save(user3.getEmail(), user7.getId());
+        followService.save(user3.getEmail(), user8.getId());
+        followService.save(user3.getEmail(), user9.getId());
+        followService.save(user4.getEmail(), user2.getId());
+        followService.save(user5.getEmail(), user2.getId());
 
         // then
-        assertEquals(2, followService.getFollowerList(user3.getEmail()).getFollowList().size());
-        assertEquals(1, followService.getFollowerList(user2.getEmail()).getFollowList().size());
-        assertEquals(0, followService.getFollowerList(user1.getEmail()).getFollowList().size());
+        assertEquals(List.of(user1.getId() ,user4.getId(), user5.getId()),
+                followService.getFollowerList(user2.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+        assertEquals(List.of(),
+                followService.getFollowerList(user1.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+        assertEquals(List.of(user3.getId()),
+                followService.getFollowerList(user5.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+        assertEquals(List.of(user1.getId()),
+                followService.getFollowerList(user3.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
     }
 
     @Test
-    @Transactional
     public void fffTest() throws Exception {
         // given
-        userService.signup(new SignupRequest("email1@gmail.com", "password1", "url1", "nick1"));
         User user1 = userService.getUserByEmail("email1@gmail.com");
-
-        userService.signup(new SignupRequest("email2@gmail.com", "password2", "url2", "nick2"));
         User user2 = userService.getUserByEmail("email2@gmail.com");
-
-        userService.signup(new SignupRequest("email3@gmail.com", "password3", "url3", "nick3"));
         User user3 = userService.getUserByEmail("email3@gmail.com");
+        User user4 = userService.getUserByEmail("email4@gmail.com");
+        User user5 = userService.getUserByEmail("email5@gmail.com");
+        User user6 = userService.getUserByEmail("email6@gmail.com");
+        User user7 = userService.getUserByEmail("email7@gmail.com");
+        User user8 = userService.getUserByEmail("email8@gmail.com");
+        User user9 = userService.getUserByEmail("email9@gmail.com");
 
         // when
         followService.save(user1.getEmail(), user2.getId());
-        followService.save(user2.getEmail(), user1.getId());
         followService.save(user1.getEmail(), user3.getId());
+        followService.save(user1.getEmail(), user4.getId());
+        followService.save(user1.getEmail(), user5.getId());
+        followService.save(user1.getEmail(), user6.getId());
+        followService.save(user2.getEmail(), user1.getId());
         followService.save(user3.getEmail(), user1.getId());
-        followService.save(user2.getEmail(), user3.getId());
-        followService.save(user3.getEmail(), user2.getId());
+        followService.save(user4.getEmail(), user1.getId());
+        followService.save(user5.getEmail(), user1.getId());
+        followService.save(user6.getEmail(), user1.getId());
 
         // then
-        assertEquals(2, followService.getFFFList(user3.getEmail()).getFollowList().size());
-        assertEquals(2, followService.getFFFList(user2.getEmail()).getFollowList().size());
-        assertEquals(2, followService.getFFFList(user1.getEmail()).getFollowList().size());
+        assertEquals(List.of(user2.getId(), user3.getId(), user4.getId(), user5.getId(), user6.getId()),
+                followService.getFFFList(user1.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+        assertEquals(List.of(user1.getId()),
+                followService.getFFFList(user2.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+        assertEquals(List.of(user1.getId()),
+                followService.getFFFList(user5.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+        assertEquals(List.of(),
+                followService.getFFFList(user8.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
     }
 }


### PR DESCRIPTION
## 제목
Post /api/v1/follow 구현

## 작업 내용
- Post /api/v1/follow 구현
- FollowService 테스트코드 고도화
- initDb에서 user 저장 시 passwordEncoder 사용하도록 변경

## 주의 사항
- 

## 이슈 번호
- #53 