### PR TITLE
SpringBoot의 timezone을 utc에서 kst로 변경

### DIFF
--- a/src/main/java/com/divide/DivideApplication.java
+++ b/src/main/java/com/divide/DivideApplication.java
@@ -4,6 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @EnableJpaAuditing
 @SpringBootApplication
 public class DivideApplication {
@@ -12,4 +15,8 @@ public class DivideApplication {
 		SpringApplication.run(DivideApplication.class, args);
 	}
 
+	@PostConstruct
+	public void postConstruct() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 }

--- a/src/main/java/com/divide/InitDb.java
+++ b/src/main/java/com/divide/InitDb.java
@@ -57,7 +57,7 @@ public class InitDb {
                         "mainFile",
                         Files.probeContentType(tempFile.toPath()),
                         false,
-                        "sample.tmp",
+                        "sample.jpg",
                         is.available(),
                         tempFile.getParentFile()
                 );

--- a/src/main/java/com/divide/config/LocalDateTimeDeSerializer.java
+++ b/src/main/java/com/divide/config/LocalDateTimeDeSerializer.java
@@ -1,0 +1,23 @@
+package com.divide.config;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.springframework.boot.jackson.JsonComponent;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+@JsonComponent
+public class LocalDateTimeDeSerializer extends JsonDeserializer<LocalDateTime> {
+    @Override
+    public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+        TreeNode jsonNode = p.getCodec().readTree(p);
+        return LocalDateTime.ofEpochSecond(Long.parseLong(jsonNode.toString()), 0, ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/com/divide/config/LocalDateTimeSerializer.java
+++ b/src/main/java/com/divide/config/LocalDateTimeSerializer.java
@@ -1,0 +1,25 @@
+package com.divide.config;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.boot.jackson.JsonComponent;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+@JsonComponent
+public class LocalDateTimeSerializer extends JsonSerializer<LocalDateTime> {
+    @Override
+    public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeNumber(value.toEpochSecond(ZoneOffset.UTC));
+    }
+}


### PR DESCRIPTION
## 제목
SpringBoot의 timezone을 utc에서 kst로 변경

## 작업 내용
- SpringBoot의 timezone을 utc에서 kst로 변경
- LocalDateTime Serializer, DeSerializer 추가
- sample이미지 파일을 tmp로 올리는 문제 해결

## 주의 사항
- 

## 이슈 번호
- #65 
- #68
- #71 