### PR TITLE
Follow 정보 조회  로직 변경

### DIFF
--- a/src/main/java/com/divide/follow/Follow.java
+++ b/src/main/java/com/divide/follow/Follow.java
@@ -3,12 +3,16 @@ package com.divide.follow;
 import com.divide.user.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor
 @Table(uniqueConstraints = {
         @UniqueConstraint(columnNames = {"follower_id", "followee_id"})
@@ -27,6 +31,9 @@ public class Follow {
     @JoinColumn(name = "followee_id")
     @NotNull
     private User followee;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
 
     public Follow(User follower, User followee) {
         this.follower = follower;

--- a/src/main/java/com/divide/follow/FollowController.java
+++ b/src/main/java/com/divide/follow/FollowController.java
@@ -27,7 +27,6 @@ public class FollowController {
     ) {
         GetFollowResponse getFollowResponse = null;
         switch (relation) {
-            case FFF -> getFollowResponse = followService.getFFFList(userDetails.getUsername());
             case FOLLOWING -> getFollowResponse = followService.getFollowingList(userDetails.getUsername());
             case FOLLOWER -> getFollowResponse = followService.getFollowerList(userDetails.getUsername());
         }

--- a/src/main/java/com/divide/follow/FollowController.java
+++ b/src/main/java/com/divide/follow/FollowController.java
@@ -6,6 +6,7 @@ import com.divide.follow.dto.request.PostFollowRequest;
 import com.divide.follow.dto.response.DeleteFollowResponse;
 import com.divide.follow.dto.response.GetFollowRequest;
 import com.divide.follow.dto.response.PostFollowResponse;
+import com.divide.post.dto.response.Result;
 import com.divide.user.User;
 import com.divide.user.UserService;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,16 +25,16 @@ public class FollowController {
     private final UserService userService;
 
     @GetMapping("follow")
-    public ResponseEntity<GetFollowResponse> getFollow(
+    public ResponseEntity getFollow(
             @AuthenticationPrincipal UserDetails userDetails,
             @ModelAttribute GetFollowRequest getFollowRequest
     ) {
-        GetFollowResponse getFollowResponse = null;
+        List<GetFollowResponse> getFollowResponse = null;
         switch (getFollowRequest.getRelation()) {
             case FOLLOWING -> getFollowResponse = followService.getFollowingList(userDetails.getUsername(), getFollowRequest.getFirst());
             case FOLLOWER -> getFollowResponse = followService.getFollowerList(userDetails.getUsername(), getFollowRequest.getFirst());
         }
-        return ResponseEntity.ok(getFollowResponse);
+        return ResponseEntity.ok(new Result(getFollowResponse));
     }
 
     @PostMapping("follow")

--- a/src/main/java/com/divide/follow/FollowController.java
+++ b/src/main/java/com/divide/follow/FollowController.java
@@ -4,6 +4,7 @@ import com.divide.follow.dto.request.DeleteFollowRequest;
 import com.divide.follow.dto.request.GetFollowResponse;
 import com.divide.follow.dto.request.PostFollowRequest;
 import com.divide.follow.dto.response.DeleteFollowResponse;
+import com.divide.follow.dto.response.GetFollowRequest;
 import com.divide.follow.dto.response.PostFollowResponse;
 import com.divide.user.User;
 import com.divide.user.UserService;
@@ -12,6 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,12 +26,12 @@ public class FollowController {
     @GetMapping("follow")
     public ResponseEntity<GetFollowResponse> getFollow(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam("relation") FollowRelation relation
+            @ModelAttribute GetFollowRequest getFollowRequest
     ) {
         GetFollowResponse getFollowResponse = null;
-        switch (relation) {
-            case FOLLOWING -> getFollowResponse = followService.getFollowingList(userDetails.getUsername());
-            case FOLLOWER -> getFollowResponse = followService.getFollowerList(userDetails.getUsername());
+        switch (getFollowRequest.getRelation()) {
+            case FOLLOWING -> getFollowResponse = followService.getFollowingList(userDetails.getUsername(), getFollowRequest.getFirst());
+            case FOLLOWER -> getFollowResponse = followService.getFollowerList(userDetails.getUsername(), getFollowRequest.getFirst());
         }
         return ResponseEntity.ok(getFollowResponse);
     }

--- a/src/main/java/com/divide/follow/FollowRelation.java
+++ b/src/main/java/com/divide/follow/FollowRelation.java
@@ -1,6 +1,7 @@
 package com.divide.follow;
 
 public enum FollowRelation {
-    FFF, FOLLOWING, FOLLOWER;
+    FOLLOWING, FOLLOWER,
+    ;
 }
 

--- a/src/main/java/com/divide/follow/FollowRepository.java
+++ b/src/main/java/com/divide/follow/FollowRepository.java
@@ -33,21 +33,6 @@ public class FollowRepository {
     public void remove(Follow follow) {
         em.remove(follow);
     }
-
-    public List<Follow> getFFFList(User user) {
-        List<Follow> followerList = getFollowerList(user);
-
-        return em.createQuery(
-                "select f1 " +
-                        "from Follow f1 " +
-                        "where f1.follower = :follower and f1.followee in :followerList",
-                Follow.class
-        )
-                .setParameter("follower", user)
-                .setParameter("followerList", followerList.stream().map(f -> f.getFollower()).toList())
-                .getResultList();
-    }
-
     public List<Follow> getFollowingList(User user) {
         return em.createQuery("select f from Follow f where f.follower = :user", Follow.class)
                 .setParameter("user", user)

--- a/src/main/java/com/divide/follow/FollowRepository.java
+++ b/src/main/java/com/divide/follow/FollowRepository.java
@@ -34,13 +34,13 @@ public class FollowRepository {
         em.remove(follow);
     }
     public List<Follow> getFollowingList(User user) {
-        return em.createQuery("select f from Follow f where f.follower = :user", Follow.class)
+        return em.createQuery("select f from Follow f where f.follower = :user order by f.createdAt desc", Follow.class)
                 .setParameter("user", user)
                 .getResultList();
     }
 
     public List<Follow> getFollowerList(User user) {
-        return em.createQuery("select f from Follow f where f.followee = :user", Follow.class)
+        return em.createQuery("select f from Follow f where f.followee = :user order by f.createdAt desc", Follow.class)
                 .setParameter("user", user)
                 .getResultList();
     }

--- a/src/main/java/com/divide/follow/FollowRepository.java
+++ b/src/main/java/com/divide/follow/FollowRepository.java
@@ -33,15 +33,19 @@ public class FollowRepository {
     public void remove(Follow follow) {
         em.remove(follow);
     }
-    public List<Follow> getFollowingList(User user) {
+    public List<Follow> getFollowingList(User user, Integer first) {
         return em.createQuery("select f from Follow f where f.follower = :user order by f.createdAt desc", Follow.class)
                 .setParameter("user", user)
+                .setFirstResult(first)
+                .setMaxResults(30)
                 .getResultList();
     }
 
-    public List<Follow> getFollowerList(User user) {
+    public List<Follow> getFollowerList(User user, Integer first) {
         return em.createQuery("select f from Follow f where f.followee = :user order by f.createdAt desc", Follow.class)
                 .setParameter("user", user)
+                .setFirstResult(first)
+                .setMaxResults(30)
                 .getResultList();
     }
 

--- a/src/main/java/com/divide/follow/FollowRepository.java
+++ b/src/main/java/com/divide/follow/FollowRepository.java
@@ -56,6 +56,13 @@ public class FollowRepository {
                 .intValue();
     }
 
+    public Boolean checkFFF(Follow follow) {
+        return em.createQuery("select count(f) > 0 from Follow f where f.followee = :other and f.follower = :me", Boolean.class)
+                .setParameter("other", follow.getFollower())
+                .setParameter("me", follow.getFollowee())
+                .getSingleResult();
+    }
+
     public Integer getFollowerCount(User user) {
         return em.createQuery("select count(f) from Follow f where f.followee = :user", Long.class)
                 .setParameter("user", user)

--- a/src/main/java/com/divide/follow/FollowService.java
+++ b/src/main/java/com/divide/follow/FollowService.java
@@ -5,6 +5,7 @@ import com.divide.exception.code.CommonErrorCode;
 import com.divide.exception.code.FollowErrorCode;
 import com.divide.exception.code.UserErrorCode;
 import com.divide.follow.dto.request.GetFollowResponse;
+import com.divide.follow.dto.request.GetFollowResponseWithRelation;
 import com.divide.user.User;
 import com.divide.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -41,30 +42,25 @@ public class FollowService {
         return follow.getId();
     }
 
-    public GetFollowResponse getFollowingList(String userEmail, Integer first) {
+    public List<GetFollowResponse> getFollowingList(String userEmail, Integer first) {
         User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new UsernameNotFoundException(""));
         List<Follow> followList = followRepository.getFollowingList(user, first);
-        return new GetFollowResponse(
-                followList.stream().map(f -> new GetFollowResponse.GetFollowResponseElement(
-                        f.getFollowee().getId(),
-                        f.getFollowee().getProfileImgUrl(),
-                        f.getFollowee().getNickname(),
-                        FollowRelation.FOLLOWING.name()
-                )).collect(Collectors.toList())
-        );
+        return followList.stream().map(f -> new GetFollowResponse(
+                f.getFollower().getId(),
+                f.getFollower().getProfileImgUrl(),
+                f.getFollower().getNickname()
+        )).collect(Collectors.toList());
     }
 
-    public GetFollowResponse getFollowerList(String userEmail, Integer first) {
+    public List<GetFollowResponse> getFollowerList(String userEmail, Integer first) {
         User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new UsernameNotFoundException(""));
         List<Follow> followList = followRepository.getFollowerList(user, first);
-        return new GetFollowResponse(
-                followList.stream().map(f -> new GetFollowResponse.GetFollowResponseElement(
-                        f.getFollower().getId(),
-                        f.getFollower().getProfileImgUrl(),
-                        f.getFollower().getNickname(),
-                        FollowRelation.FOLLOWER.name()
-                )).collect(Collectors.toList())
-        );
+        return followList.stream().map(f -> new GetFollowResponseWithRelation(
+                f.getFollower().getId(),
+                f.getFollower().getProfileImgUrl(),
+                f.getFollower().getNickname(),
+                followRepository.checkFFF(f)
+        )).collect(Collectors.toList());
     }
 
     public Integer getFollowingCount(String userEmail) {

--- a/src/main/java/com/divide/follow/FollowService.java
+++ b/src/main/java/com/divide/follow/FollowService.java
@@ -3,6 +3,7 @@ package com.divide.follow;
 import com.divide.exception.RestApiException;
 import com.divide.exception.code.CommonErrorCode;
 import com.divide.exception.code.FollowErrorCode;
+import com.divide.exception.code.UserErrorCode;
 import com.divide.follow.dto.request.GetFollowResponse;
 import com.divide.user.User;
 import com.divide.user.UserRepository;
@@ -40,8 +41,9 @@ public class FollowService {
         return follow.getId();
     }
 
-    public GetFollowResponse getFollowingList(String userEmail) {
-        List<Follow> followList = followRepository.getFollowingList(userRepository.findByEmail(userEmail).orElseThrow());
+    public GetFollowResponse getFollowingList(String userEmail, Integer first) {
+        User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new UsernameNotFoundException(""));
+        List<Follow> followList = followRepository.getFollowingList(user, first);
         return new GetFollowResponse(
                 followList.stream().map(f -> new GetFollowResponse.GetFollowResponseElement(
                         f.getFollowee().getId(),
@@ -52,8 +54,9 @@ public class FollowService {
         );
     }
 
-    public GetFollowResponse getFollowerList(String userEmail) {
-        List<Follow> followList = followRepository.getFollowerList(userRepository.findByEmail(userEmail).orElseThrow());
+    public GetFollowResponse getFollowerList(String userEmail, Integer first) {
+        User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new UsernameNotFoundException(""));
+        List<Follow> followList = followRepository.getFollowerList(user, first);
         return new GetFollowResponse(
                 followList.stream().map(f -> new GetFollowResponse.GetFollowResponseElement(
                         f.getFollower().getId(),

--- a/src/main/java/com/divide/follow/FollowService.java
+++ b/src/main/java/com/divide/follow/FollowService.java
@@ -40,18 +40,6 @@ public class FollowService {
         return follow.getId();
     }
 
-    public GetFollowResponse getFFFList(String userEmail) {
-        List<Follow> followList = followRepository.getFFFList(userRepository.findByEmail(userEmail).orElseThrow());
-        return new GetFollowResponse(
-                followList.stream().map(f -> new GetFollowResponse.GetFollowResponseElement(
-                        f.getFollowee().getId(),
-                        f.getFollowee().getProfileImgUrl(),
-                        f.getFollowee().getNickname(),
-                        FollowRelation.FFF.name()
-                )).collect(Collectors.toList())
-        );
-    }
-
     public GetFollowResponse getFollowingList(String userEmail) {
         List<Follow> followList = followRepository.getFollowingList(userRepository.findByEmail(userEmail).orElseThrow());
         return new GetFollowResponse(

--- a/src/main/java/com/divide/follow/dto/request/GetFollowResponse.java
+++ b/src/main/java/com/divide/follow/dto/request/GetFollowResponse.java
@@ -8,14 +8,7 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 public class GetFollowResponse {
-    List<GetFollowResponseElement> followList;
-
-    @AllArgsConstructor
-    @Getter
-    public static class GetFollowResponseElement {
-        private Long userId;
-        private String profileImgUrl;
-        private String nickname;
-        private String relation;
-    }
+    private Long userId;
+    private String profileImgUrl;
+    private String nickname;
 }

--- a/src/main/java/com/divide/follow/dto/request/GetFollowResponseWithRelation.java
+++ b/src/main/java/com/divide/follow/dto/request/GetFollowResponseWithRelation.java
@@ -1,0 +1,13 @@
+package com.divide.follow.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class GetFollowResponseWithRelation extends GetFollowResponse {
+    private Boolean isFFF;
+
+    public GetFollowResponseWithRelation(Long userId, String profileImgUrl, String nickname, Boolean isFFF) {
+        super(userId, profileImgUrl, nickname);
+        this.isFFF = isFFF;
+    }
+}

--- a/src/main/java/com/divide/follow/dto/response/GetFollowRequest.java
+++ b/src/main/java/com/divide/follow/dto/response/GetFollowRequest.java
@@ -1,0 +1,21 @@
+package com.divide.follow.dto.response;
+
+import com.divide.follow.FollowRelation;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class GetFollowRequest {
+    @NotNull
+    private FollowRelation relation;
+
+    @PositiveOrZero
+    private Integer first = 0;
+}

--- a/src/test/java/com/divide/follow/FollowServiceTest.java
+++ b/src/test/java/com/divide/follow/FollowServiceTest.java
@@ -118,40 +118,4 @@ class FollowServiceTest {
         assertEquals(List.of(user1.getId()),
                 followService.getFollowerList(user3.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
     }
-
-    @Test
-    public void fffTest() throws Exception {
-        // given
-        User user1 = userService.getUserByEmail("email1@gmail.com");
-        User user2 = userService.getUserByEmail("email2@gmail.com");
-        User user3 = userService.getUserByEmail("email3@gmail.com");
-        User user4 = userService.getUserByEmail("email4@gmail.com");
-        User user5 = userService.getUserByEmail("email5@gmail.com");
-        User user6 = userService.getUserByEmail("email6@gmail.com");
-        User user7 = userService.getUserByEmail("email7@gmail.com");
-        User user8 = userService.getUserByEmail("email8@gmail.com");
-        User user9 = userService.getUserByEmail("email9@gmail.com");
-
-        // when
-        followService.save(user1.getEmail(), user2.getId());
-        followService.save(user1.getEmail(), user3.getId());
-        followService.save(user1.getEmail(), user4.getId());
-        followService.save(user1.getEmail(), user5.getId());
-        followService.save(user1.getEmail(), user6.getId());
-        followService.save(user2.getEmail(), user1.getId());
-        followService.save(user3.getEmail(), user1.getId());
-        followService.save(user4.getEmail(), user1.getId());
-        followService.save(user5.getEmail(), user1.getId());
-        followService.save(user6.getEmail(), user1.getId());
-
-        // then
-        assertEquals(List.of(user2.getId(), user3.getId(), user4.getId(), user5.getId(), user6.getId()),
-                followService.getFFFList(user1.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
-        assertEquals(List.of(user1.getId()),
-                followService.getFFFList(user2.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
-        assertEquals(List.of(user1.getId()),
-                followService.getFFFList(user5.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
-        assertEquals(List.of(),
-                followService.getFFFList(user8.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
-    }
 }

--- a/src/test/java/com/divide/follow/FollowServiceTest.java
+++ b/src/test/java/com/divide/follow/FollowServiceTest.java
@@ -72,13 +72,13 @@ class FollowServiceTest {
 
         // then
         assertEquals(List.of(user2.getId(), user3.getId()),
-                followService.getFollowingList(user1.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowingList(user1.getEmail(), 0).stream().map(GetFollowResponse::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(),
-                followService.getFollowingList(user2.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowingList(user2.getEmail(), 0).stream().map(GetFollowResponse::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(user4.getId(), user5.getId(), user6.getId(), user7.getId(), user8.getId(), user9.getId()),
-                followService.getFollowingList(user3.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowingList(user3.getEmail(), 0).stream().map(GetFollowResponse::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(),
-                followService.getFollowingList(user8.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowingList(user8.getEmail(), 0).stream().map(GetFollowResponse::getUserId).collect(Collectors.toList()));
     }
 
     @Test
@@ -108,12 +108,12 @@ class FollowServiceTest {
 
         // then
         assertEquals(List.of(user1.getId() ,user4.getId(), user5.getId()),
-                followService.getFollowerList(user2.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowerList(user2.getEmail(), 0).stream().map(GetFollowResponse::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(),
-                followService.getFollowerList(user1.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowerList(user1.getEmail(), 0).stream().map(GetFollowResponse::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(user3.getId()),
-                followService.getFollowerList(user5.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowerList(user5.getEmail(), 0).stream().map(GetFollowResponse::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(user1.getId()),
-                followService.getFollowerList(user3.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowerList(user3.getEmail(), 0).stream().map(GetFollowResponse::getUserId).collect(Collectors.toList()));
     }
 }

--- a/src/test/java/com/divide/follow/FollowServiceTest.java
+++ b/src/test/java/com/divide/follow/FollowServiceTest.java
@@ -10,9 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
@@ -63,24 +61,24 @@ class FollowServiceTest {
         User user9 = userService.getUserByEmail("email9@gmail.com");
 
         // when
-        followService.save(user1.getEmail(), user2.getId());
-        followService.save(user1.getEmail(), user3.getId());
-        followService.save(user3.getEmail(), user4.getId());
-        followService.save(user3.getEmail(), user5.getId());
-        followService.save(user3.getEmail(), user6.getId());
-        followService.save(user3.getEmail(), user7.getId());
-        followService.save(user3.getEmail(), user8.getId());
-        followService.save(user3.getEmail(), user9.getId());
+        followService.save(user1, user2);
+        followService.save(user1, user3);
+        followService.save(user3, user4);
+        followService.save(user3, user5);
+        followService.save(user3, user6);
+        followService.save(user3, user7);
+        followService.save(user3, user8);
+        followService.save(user3, user9);
 
         // then
         assertEquals(List.of(user2.getId(), user3.getId()),
-                followService.getFollowingList(user1.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowingList(user1.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(),
-                followService.getFollowingList(user2.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowingList(user2.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(user4.getId(), user5.getId(), user6.getId(), user7.getId(), user8.getId(), user9.getId()),
-                followService.getFollowingList(user3.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowingList(user3.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(),
-                followService.getFollowingList(user8.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowingList(user8.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
     }
 
     @Test
@@ -97,25 +95,25 @@ class FollowServiceTest {
         User user9 = userService.getUserByEmail("email9@gmail.com");
 
         // when
-        followService.save(user1.getEmail(), user2.getId());
-        followService.save(user1.getEmail(), user3.getId());
-        followService.save(user3.getEmail(), user4.getId());
-        followService.save(user3.getEmail(), user5.getId());
-        followService.save(user3.getEmail(), user6.getId());
-        followService.save(user3.getEmail(), user7.getId());
-        followService.save(user3.getEmail(), user8.getId());
-        followService.save(user3.getEmail(), user9.getId());
-        followService.save(user4.getEmail(), user2.getId());
-        followService.save(user5.getEmail(), user2.getId());
+        followService.save(user1, user2);
+        followService.save(user1, user3);
+        followService.save(user3, user4);
+        followService.save(user3, user5);
+        followService.save(user3, user6);
+        followService.save(user3, user7);
+        followService.save(user3, user8);
+        followService.save(user3, user9);
+        followService.save(user4, user2);
+        followService.save(user5, user2);
 
         // then
         assertEquals(List.of(user1.getId() ,user4.getId(), user5.getId()),
-                followService.getFollowerList(user2.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowerList(user2.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(),
-                followService.getFollowerList(user1.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowerList(user1.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(user3.getId()),
-                followService.getFollowerList(user5.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowerList(user5.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
         assertEquals(List.of(user1.getId()),
-                followService.getFollowerList(user3.getEmail()).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
+                followService.getFollowerList(user3.getEmail(), 0).getFollowList().stream().map(GetFollowResponse.GetFollowResponseElement::getUserId).collect(Collectors.toList()));
     }
 }


### PR DESCRIPTION
## 제목
Follow 정보 조회  로직 변경

## 작업 내용
- 맞팔 api 삭제
- 팔로우 정보 api에서 팔로우를 한 시간 순서대로 정렳해서 내려주도록 변경
- 팔로우 api에 페이지네이션 적용
- 팔로워 정보에 맞팔 정보를 추가해서 내려주도록 변경

## 주의 사항
- 

## 이슈 번호
- #108 