### PR TITLE
Update: POST /api/v1/auth/login API에서 userId 반환

### DIFF
--- a/src/main/java/com/divide/auth/AuthController.java
+++ b/src/main/java/com/divide/auth/AuthController.java
@@ -7,6 +7,7 @@ import com.divide.auth.dto.response.LoginResponse;
 import com.divide.security.JwtFilter;
 import com.divide.auth.dto.request.LoginRequest;
 import com.divide.security.TokenProvider;
+import com.divide.user.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
@@ -21,6 +22,7 @@ import javax.validation.constraints.NotNull;
 public class AuthController {
     private final AuthService authService;
     private final TokenProvider tokenProvider;
+    private final UserService userService;
 
     @PostMapping("/auth/login")
     public ResponseEntity<LoginResponse> login(
@@ -30,8 +32,9 @@ public class AuthController {
 
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + jwt);
+        Long userId = userService.getUserByEmail(loginRequest.getEmail()).getId();
 
-        return ResponseEntity.ok(new LoginResponse(jwt));
+        return ResponseEntity.ok(new LoginResponse(jwt, userId));
     }
 
     @GetMapping("/auth/kakaoTest")

--- a/src/main/java/com/divide/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/divide/auth/dto/response/LoginResponse.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LoginResponse {
     private String token;
+    private Long userId;
 }


### PR DESCRIPTION
프론트에서 채팅 구현을 위해 필요한 userId를 반환해주기 위해 인증 API 변경

## 제목
POST /api/v1/auth/login API에서 userId 반환

## 작업 내용
- 

## 주의 사항
- 

## 이슈 번호
- #125 