### PR TITLE
API를 통해 userId를 클라이언트에 내려주도록 변경

### DIFF
--- a/src/main/java/com/divide/exception/code/UserErrorCode.java
+++ b/src/main/java/com/divide/exception/code/UserErrorCode.java
@@ -13,7 +13,9 @@ public enum UserErrorCode implements ErrorCode {
     OTHER_USER_IS_ME(HttpStatus.BAD_REQUEST, "Requested other user is me"),
     INVALID_BADGE_NAME(HttpStatus.BAD_REQUEST, "BadgeName is not valid"),
     ALREADY_SET_BADGE_NAME(HttpStatus.FORBIDDEN, "BadgeName is already set as request"),
-    ALREADY_REGISTERED_BADGE(HttpStatus.FORBIDDEN, "Badge is already registered");
+    ALREADY_REGISTERED_BADGE(HttpStatus.FORBIDDEN, "Badge is already registered"),
+    LOCATION_NOT_SET(HttpStatus.FORBIDDEN, "Location is not set"),
+    ;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/divide/user/User.java
+++ b/src/main/java/com/divide/user/User.java
@@ -104,6 +104,10 @@ public class User {
         return Optional.of(this.fcmToken.getToken());
     }
 
+    public Optional<Location> getLocation() {
+        return Optional.ofNullable(location);
+    }
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }

--- a/src/main/java/com/divide/user/UserController.java
+++ b/src/main/java/com/divide/user/UserController.java
@@ -5,6 +5,7 @@ import com.divide.common.CommonLocationResponse;
 import com.divide.exception.RestApiException;
 import com.divide.exception.code.UserErrorCode;
 import com.divide.follow.FollowService;
+import com.divide.location.Location;
 import com.divide.user.dto.request.PatchUserRequest;
 import com.divide.user.dto.request.PostUserBadgeRequest;
 import com.divide.user.dto.request.PostUserFcmTokenRequest;
@@ -79,13 +80,11 @@ public class UserController {
                 user.getSelectedBadge().getBadgeName().getKrName(),
                 user.getSelectedBadge().getBadgeName().getDescription());
 
-        CommonLocationResponse locationResponse = null;
-        if (user.getLocation() != null) {
-            locationResponse = new CommonLocationResponse(
-                    user.getLocation().getLatitude(),
-                    user.getLocation().getLongitude()
-            );
-        }
+        Location userLocation = user.getLocation().orElseThrow(() -> new RestApiException(UserErrorCode.LOCATION_NOT_SET));
+        CommonLocationResponse locationResponse = new CommonLocationResponse(
+                userLocation.getLatitude(),
+                userLocation.getLongitude()
+        );
 
         return GetUserResponseV2.builder()
                 .email(user.getEmail())

--- a/src/main/java/com/divide/user/UserController.java
+++ b/src/main/java/com/divide/user/UserController.java
@@ -87,6 +87,7 @@ public class UserController {
         );
 
         return GetUserResponseV2.builder()
+                .userId(user.getId())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .profileImgUrl(user.getProfileImgUrl())

--- a/src/main/java/com/divide/user/dto/response/GetUserResponseV2.java
+++ b/src/main/java/com/divide/user/dto/response/GetUserResponseV2.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class GetUserResponseV2 {
+    private Long userId;
     private String email;
     private String nickname;
     private String profileImgUrl;


### PR DESCRIPTION
## 제목
API를 통해 userId를 클라이언트에 내려주도록 변경

## 작업 내용
- Update: User의 Location이 비어있을 때 excetpion이 발생하도록 변경
- Update: GET /api/v2/user API에서 userId도 반환하도록 변경

## 주의 사항
- 

## 이슈 번호
- #140